### PR TITLE
IssuesDataTable: update description edit flow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "pwa-chrome",
+			"request": "launch",
+			"name": "Launch Chrome against localhost",
+			"url": "http://localhost:4200",
+			"webRoot": "${workspaceFolder}"
+		}
+	]
+}

--- a/src/app/phase-bug-reporting/issue/issue.component.html
+++ b/src/app/phase-bug-reporting/issue/issue.component.html
@@ -1,3 +1,3 @@
 <div>
-  <app-view-issue [issueId]="this.issueId" [issueComponents]="this.issueComponents"></app-view-issue>
+  <app-view-issue [issueId]="this.issueId" [isRowEditClicked]="this.isRowEditClicked" [issueComponents]="this.issueComponents"></app-view-issue>
 </div>

--- a/src/app/phase-bug-reporting/issue/issue.component.ts
+++ b/src/app/phase-bug-reporting/issue/issue.component.ts
@@ -9,6 +9,7 @@ import { ViewIssueComponent, ISSUE_COMPONENTS } from '../../shared/view-issue/vi
 })
 export class IssueComponent implements OnInit {
   issueId: number;
+  isRowEditClicked: boolean;
 
   readonly issueComponents: ISSUE_COMPONENTS[] = [
     ISSUE_COMPONENTS.TESTER_POST,
@@ -21,6 +22,7 @@ export class IssueComponent implements OnInit {
   constructor(private route: ActivatedRoute) { }
 
   ngOnInit() {
+    this.isRowEditClicked = window.history.state.isEditClicked;
     this.route.params.subscribe(
       params => {
         this.issueId = + params['issue_id'];

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -113,7 +113,8 @@
       </button>
       <ng-template #tryEditIssue>
         <button *ngIf="permissions.isIssueEditable() && this.isActionVisible(action_buttons.FIX_ISSUE)"
-                mat-button color="accent"
+                mat-button color="accent" 
+                (click)="this.navigateToEdit(issue.id)"
                 style="transform: scale(0.8)" matTooltip="Edit this issue" >
           <mat-icon>edit</mat-icon>
         </button>

--- a/src/app/shared/issue-tables/issue-tables.component.ts
+++ b/src/app/shared/issue-tables/issue-tables.component.ts
@@ -11,6 +11,7 @@ import { IssuesDataTable } from './IssuesDataTable';
 import { MatPaginator, MatSort } from '@angular/material';
 import { PhaseService } from '../../core/services/phase.service';
 import { LoggingService } from '../../core/services/logging.service';
+import { Router } from '@angular/router';
 
 export enum ACTION_BUTTONS {
   VIEW_IN_WEB,
@@ -46,7 +47,8 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
               private issueService: IssueService,
               private phaseService: PhaseService,
               private errorHandlingService: ErrorHandlingService,
-              private loggingService: LoggingService) { }
+              private loggingService: LoggingService,
+              private router: Router) { }
 
   ngOnInit() {
     this.issues = new IssuesDataTable(this.issueService, this.errorHandlingService, this.sort,
@@ -152,5 +154,9 @@ export class IssueTablesComponent implements OnInit, AfterViewInit {
       this.errorHandlingService.handleError(error);
     });
     event.stopPropagation();
+  }
+
+  navigateToEdit(id: number) {
+    this.router.navigate(['/phaseBugReporting/issues/' + id], { state: {isEditClicked: true} });
   }
 }

--- a/src/app/shared/issue/description/description.component.ts
+++ b/src/app/shared/issue/description/description.component.ts
@@ -26,6 +26,7 @@ export class DescriptionComponent implements OnInit {
   @Input() issue: Issue;
   @Input() title: string;
   @Input() isEditing: boolean;
+  @Input() isRowEditClicked: boolean;
   @Output() issueUpdated = new EventEmitter<Issue>();
   @Output() changeEditState = new EventEmitter<boolean>();
 
@@ -42,6 +43,10 @@ export class DescriptionComponent implements OnInit {
       description: [''],
     });
     this.submitButtonText = SUBMIT_BUTTON_TEXT.SAVE;
+
+    if (this.isRowEditClicked) {
+      this.changeToEditMode();
+    }
   }
 
   changeToEditMode() {

--- a/src/app/shared/view-issue/view-issue.component.html
+++ b/src/app/shared/view-issue/view-issue.component.html
@@ -12,7 +12,8 @@
       <!-- Tester's Post -->
       <app-issue-description [isEditing]="isIssueDescriptionEditing" (changeEditState)="updateDescriptionEditState($event)"
         *ngIf="this.isComponentVisible(issueComponentsEnum.TESTER_POST)"
-        [issue]="issue" title="Description of Issue" (issueUpdated)="updateIssue($event)">
+        [issue]="issue" title="Description of Issue" (issueUpdated)="updateIssue($event)"
+        [isRowEditClicked]="this.isRowEditClicked">
       </app-issue-description>
 
       <!-- Team's Response -->

--- a/src/app/shared/view-issue/view-issue.component.ts
+++ b/src/app/shared/view-issue/view-issue.component.ts
@@ -46,6 +46,7 @@ export class ViewIssueComponent implements OnInit, OnDestroy, OnChanges {
 
   @Input() issueId: number;
   @Input() issueComponents: ISSUE_COMPONENTS[];
+  @Input() isRowEditClicked: boolean;
 
   public readonly issueComponentsEnum = ISSUE_COMPONENTS;
   public readonly userRole = UserRole;
@@ -60,6 +61,9 @@ export class ViewIssueComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit() {
     this.getAndPollIssue(this.issueId);
+    if (this.isRowEditClicked) {
+      this.isIssueDescriptionEditing = true;
+    }
   }
 
   /**


### PR DESCRIPTION
### Summary:
Update Edit flow from Issues Table 

### Changes Made:
* Add new variable isRowEditClicked as boolean flag
* Pass isRowEditClicked flag down the component tree
* Update ngOnInit() method to set edit mode for Issue description when user clicks edit icon in Issues

### Proposed Commit Message:
```
On edit button click from issues table, the user will be directed to the
selected Issue but will still have to press another edit button to edit
the details of the Issue

Users requires more clicks in order to edit the information
they want to as they could expect being able to edit content
straightaway upon pressing the edit button from the table

Let's reduce the number of clicks a user would need when selecting
the edit icon from the table by passing an edit flag on route navigation
that sets the Issue's description to edit mode
```

### Demo:

https://user-images.githubusercontent.com/35250069/126899384-9d81a2de-6e88-4166-a383-43e3b1ad0756.mov

